### PR TITLE
Add `print_r` to "errorlog" list

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/framework.ini
+++ b/administrator/components/com_jedchecker/libraries/rules/framework.ini
@@ -28,7 +28,7 @@ warning_groups="superglobals"
 superglobals="$_GET,$_POST,$_SESSION,$_COOKIE,$_FILES"
 
 notice_groups="errorlog,todo"
-errorlog="error_log,var_export,var_dump"
+errorlog="error_log,var_export,var_dump,print_r"
 todo="@TODO"
 
 compatibility_groups="notinj3,deprecated,jerr,DS,strict"


### PR DESCRIPTION
Display a notice for `print_r` function (along with `error_log`, `var_export`, `var_dump`)