### PR TITLE
Fix id prefix for consistency

### DIFF
--- a/administrator/components/com_jedchecker/models/report.php
+++ b/administrator/components/com_jedchecker/models/report.php
@@ -217,7 +217,7 @@ class JEDcheckerReport extends JObject
 			if ($compat_count > 0)
 			{
 
-				$collapseID = uniqid('warning_');
+				$collapseID = uniqid('compat_');
 
 				$html[] = '<div class="alert alert-warning" data-toggle="collapse" data-target="#' . $collapseID . '"><strong>' . $compat_count . ' ' . JText::_('COM_JEDCHECKER_COMPAT_ISSUES') . '</strong> - Click to View Details</div>';
 				$html[] = '<div id="' . $collapseID . '" class="collapse"><ul class="alert alert-warning">';


### PR DESCRIPTION
An attempt to fix issue #45 (`uniqid` has microsecond precision, so it is actually possible to get  identical `id`, maybe it would be better to use `mt_rand` instead of `uniqid` to avoid conflicts at all)