### PR TITLE
Support exit in entry point check

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/jexec.php
+++ b/administrator/components/com_jedchecker/libraries/rules/jexec.php
@@ -112,10 +112,16 @@ class JedcheckerRulesJexec extends JEDcheckerRule
 			//  "or" may not be present depending on syntax
 			$pos_3 = stripos($line, 'die');
 
-			// Skip the line if "die" is not found
+			// Check for "exit"
 			if ($pos_3 === false)
 			{
-				continue;
+				$pos_3 = stripos($line, 'exit');
+
+				// Skip the line if "die" or "exit" is not found
+				if ($pos_3 === false)
+				{
+					continue;
+				}
 			}
 
 			// Search for the constant name


### PR DESCRIPTION
`exit` is the same as `die` but currently only `die` is supported. This fixes that.

### Testing Instructions

Use this check in PHP file:

>defined('_JEXEC') or exit;

### Expected Result

Rule PH2 passes.

### Actual Result

Rule PH2 fails.