### PR TITLE
Bye-bye, PHP4

### DIFF
--- a/administrator/components/com_jedchecker/controllers/uploads.php
+++ b/administrator/components/com_jedchecker/controllers/uploads.php
@@ -25,10 +25,9 @@ use Joomla\Archive\Archive;
  */
 class JedcheckerControllerUploads extends JControllerlegacy
 {
-
-var $path         = null;
-var $pathArchive  = null;
-var $pathUnzipped = null;
+	public $path;
+	public $pathArchive;
+	public $pathUnzipped;
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
Convert `var`-based property declarations into the `public`-based ones (not sure about the visibility)