### PR TITLE
Fix displayed filepaths on Windows

### DIFF
--- a/administrator/components/com_jedchecker/controllers/police.raw.php
+++ b/administrator/components/com_jedchecker/controllers/police.raw.php
@@ -65,7 +65,7 @@ class JedcheckerControllerPolice extends JControllerLegacy
 	protected function police($class, $folder)
 	{
 		// Prepare rule properties
-		$properties = array('basedir' => $folder);
+		$properties = array('basedir' => JPath::clean($folder));
 
 		// Create instance of the rule
 		$police = new $class($properties);


### PR DESCRIPTION
### Summary of Changes
`JPath::clean` is necessary to correctly remove full file path prefix in `JEDcheckerReport::addItem`.

### Testing Instructions
Install JED checker on Windows and check any extension.

### Actual result BEFORE applying this Pull Request
Full path (starting from the disk letter) is displayed in messages

### Expected result AFTER applying this Pull Request
Relative paths are displayed

### Documentation Changes Required
None