### PR TITLE
Accept .zip and .gz files only

### DIFF
--- a/administrator/components/com_jedchecker/views/uploads/tmpl/default.php
+++ b/administrator/components/com_jedchecker/views/uploads/tmpl/default.php
@@ -87,7 +87,7 @@ function add_validation() {
 						<div class="form-row">
 							<div class="col-md-6 mb-3">
 								<div class="custom-file">
-									<input type="file" class="custom-file-input" name="extension" id="extension" required>
+									<input type="file" class="custom-file-input" name="extension" id="extension" required accept=".bz2,.bzip2,.gz,.gzip,.tar,.tbz2,.tgz,.zip">
 									<label class="custom-file-label" for="extension"><?php echo JText::_('COM_JEDCHECKER_UPLOAD_FILE'); ?></label>
 									<div class="invalid-feedback"><?php echo JText::_('COM_JEDCHECKER_EMPTY_UPLOAD_FIELD'); ?></div>
 								</div>


### PR DESCRIPTION
### Summary of Changes
MIME types for `accept` attribute corresponds to the following file types:

    application/zip          => .zip (both Chromium and Firefox)
    application/x-gzip       => .gz  (both Chromium and Firefox),
                                .tgz (Chromium only)
    application/x-compressed => .tgz (Firefox only)
    application/x-tar        => .tar (both Chromium and Firefox)

Note: iOS Safari doesn't support file extensions in the `accept` attribute, so MIME types is the only working solution.

### Testing Instructions
Click on Browse button

### Actual result BEFORE applying this Pull Request
All files are listed.

### Expected result AFTER applying this Pull Request
Supported archives are listed only (if `accept` attribute is supported by the browser, otherwise all files are listed)

### Documentation Changes Required
None