### PR TITLE
Update Encoding rule

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/encoding.ini
+++ b/administrator/components/com_jedchecker/libraries/rules/encoding.ini
@@ -7,4 +7,4 @@
 ; @license    GNU General Public License version 2 or later; see LICENSE.txt
 
 ; The valid constants to search for
-encodings ="base64_decode,base64_encode"
+encodings ="base64_decode,base64_encode,zlib_decode,zlib_encode"

--- a/administrator/components/com_jedchecker/libraries/rules/encoding.ini
+++ b/administrator/components/com_jedchecker/libraries/rules/encoding.ini
@@ -7,4 +7,4 @@
 ; @license    GNU General Public License version 2 or later; see LICENSE.txt
 
 ; The valid constants to search for
-encodings ="base64"
+encodings ="base64_decode,base64_encode"

--- a/administrator/components/com_jedchecker/libraries/rules/encoding.php
+++ b/administrator/components/com_jedchecker/libraries/rules/encoding.php
@@ -80,11 +80,7 @@ class JedcheckerRulesEncoding extends JEDcheckerRule
 
 		// Get the functions to look for
 		$encodings = explode(',', $this->params->get('encodings'));
-
-		foreach ($encodings as $i => $encoding)
-		{
-			$encodings[$i] = trim($encoding);
-		}
+		$encodings = array_map('trim', $encodings);
 
 		$found = false;
 

--- a/administrator/components/com_jedchecker/libraries/rules/encoding.php
+++ b/administrator/components/com_jedchecker/libraries/rules/encoding.php
@@ -61,8 +61,7 @@ class JedcheckerRulesEncoding extends JEDcheckerRule
 			// Try to find the base64 use in the file
 			if ($this->find($file))
 			{
-				// Add as error to the report if it was not found
-				$this->report->addError($file, JText::_('COM_JEDCHECKER_ERROR_ENCODING'));
+				// The error has been added by the find() method
 			}
 		}
 	}
@@ -82,22 +81,29 @@ class JedcheckerRulesEncoding extends JEDcheckerRule
 		// Get the functions to look for
 		$encodings = explode(',', $this->params->get('encodings'));
 
-		foreach ($encodings as $encoding)
+		foreach ($encodings as $i => $encoding)
 		{
-			$encoding = trim($encoding);
+			$encodings[$i] = trim($encoding);
+		}
 
-			foreach ($content AS $line)
+		$found = false;
+
+		foreach ($content as $i => $line)
+		{
+			foreach ($encodings as $encoding)
 			{
 				// Search for "base64"
 				$pos_1 = stripos($line, $encoding);
 
 				if ($pos_1 !== false)
 				{
-					return true;
+					$found = true;
+					$this->report->addError($file, JText::_('COM_JEDCHECKER_ERROR_ENCODING'), $i + 1, $line);
+					break;
 				}
 			}
 		}
 
-		return false;
+		return $found;
 	}
 }

--- a/administrator/components/com_jedchecker/libraries/rules/encoding.php
+++ b/administrator/components/com_jedchecker/libraries/rules/encoding.php
@@ -94,7 +94,7 @@ class JedcheckerRulesEncoding extends JEDcheckerRule
 				if ($pos_1 !== false)
 				{
 					$found = true;
-					$this->report->addError($file, JText::_('COM_JEDCHECKER_ERROR_ENCODING'), $i + 1, $line);
+					$this->report->addWarning($file, JText::_('COM_JEDCHECKER_ERROR_ENCODING'), $i + 1, $line);
 					break;
 				}
 			}


### PR DESCRIPTION
### Summary of Changes
1) Show line number in the case of encoding function found.
2) To avoid false-positives (e.g. in the case of data-uri), `base64` is replaced by full function names `base64_decode` and `base64_encode`.
3) `zlib_decode` and `zlib_encode` are added to the list as well.

