### PR TITLE
Add several GPLV2-compatible licenses

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/gpl.ini
+++ b/administrator/components/com_jedchecker/libraries/rules/gpl.ini
@@ -11,4 +11,4 @@
 ;
 
 ; The valid constants to search for
-constants="BSD"
+constants="BSD,MIT,Public Domain,X11"


### PR DESCRIPTION
Only BSD was accepted, while there are several other GPL-compatible licenses. Only GPL V2 compatible licenses have been added.

There are several more possible licenses if we take GPL V3 into account but we would need to identify the exact license the extension is released under to be able to decide which list to use.
