### PR TITLE
Check folders exist (XMLFiles rules)

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/xmlfiles.php
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlfiles.php
@@ -55,6 +55,13 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 	protected $errors;
 
 	/**
+	 * List of warnings.
+	 *
+	 * @var    string[]
+	 */
+	protected $warnings;
+
+	/**
 	 * Manifest's directory
 	 *
 	 * @var    string
@@ -98,6 +105,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 		}
 
 		$this->errors = array();
+		$this->warnings = array();
 
 		// Check declared files and folders do exist
 
@@ -112,7 +120,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 			$node = $xml->files;
 
 			// Get path to site files from "folder" attribute
-			$sitedir = isset($node['folder']) ? $node['folder'] . '/' : '';
+			$sitedir = $this->getSourceFolder($node);
 
 			$this->checkFiles($node->filename, $sitedir);
 			$this->checkFiles($node->file, $sitedir);
@@ -123,7 +131,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 		if (isset($xml->media))
 		{
 			$node = $xml->media;
-			$dir = isset($node['folder']) ? $node['folder'] . '/' : '';
+			$dir = $this->getSourceFolder($node);
 
 			$this->checkFiles($node->filename, $dir);
 			$this->checkFiles($node->file, $dir);
@@ -134,7 +142,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 		if (isset($xml->fonts))
 		{
 			$node = $xml->fonts;
-			$dir = isset($node['folder']) ? $node['folder'] . '/' : '';
+			$dir = $this->getSourceFolder($node);
 
 			$this->checkFiles($node->filename, $dir);
 			$this->checkFiles($node->file, $dir);
@@ -145,7 +153,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 		if (isset($xml->languages))
 		{
 			$node = $xml->languages;
-			$dir = isset($node['folder']) ? $node['folder'] . '/' : '';
+			$dir = $this->getSourceFolder($node);
 
 			$this->checkFiles($node->language, $dir);
 		}
@@ -158,7 +166,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 			$node = $xml->administration->files;
 
 			// Get path to admin files from "folder" attribute
-			$admindir = isset($node['folder']) ? $node['folder'] . '/' : '';
+			$admindir = $this->getSourceFolder($node);
 
 			$this->checkFiles($node->filename, $admindir);
 			$this->checkFiles($node->file, $admindir);
@@ -169,7 +177,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 		if (isset($xml->administration->media))
 		{
 			$node = $xml->administration->media;
-			$dir = isset($node['folder']) ? $node['folder'] . '/' : '';
+			$dir = $this->getSourceFolder($node);
 
 			$this->checkFiles($node->filename, $dir);
 			$this->checkFiles($node->file, $dir);
@@ -180,7 +188,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 		if (isset($xml->administration->languages))
 		{
 			$node = $xml->administration->languages;
-			$dir = isset($node['folder']) ? $node['folder'] . '/' : '';
+			$dir = $this->getSourceFolder($node);
 
 			$this->checkFiles($node->language, $dir);
 		}
@@ -190,7 +198,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 		if (isset($xml->fileset->files))
 		{
 			$node = $xml->fileset->files;
-			$dir = isset($node['folder']) ? $node['folder'] . '/' : '';
+			$dir = $this->getSourceFolder($node);
 
 			$this->checkFiles($node->filename, $dir);
 			$this->checkFiles($node->file, $dir);
@@ -286,8 +294,39 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 			$this->report->addError($file, implode('<br />', $this->errors));
 		}
 
+		if (count($this->warnings))
+		{
+			$this->report->addWarning($file, implode('<br />', $this->warnings));
+		}
+
 		// All checks passed. Return true
 		return true;
+	}
+
+	/**
+	 * Get source folder for a node
+	 *
+	 * @param   SimpleXMLElement  $node  The node to check for "folder" attribute
+	 *
+	 * @return  string
+	 */
+	protected function getSourceFolder($node)
+	{
+		if (!isset($node['folder']))
+		{
+			return '';
+		}
+
+		$folder = (string) $node['folder'];
+
+		if (is_dir($this->basedir . $folder))
+		{
+			return $folder . '/';
+		}
+
+		$this->warnings[] = JText::sprintf('COM_JEDCHECKER_XML_FILES_FOLDER_NOT_FOUND', $folder);
+
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue #131.

PS. Non-existing folders in the `folder` attribute(s) are treated as warnings, because Joomla's extension installer is tolerant to such errors.