### PR TITLE
XMLFiles: Add support of api section in components (J!4.0+)

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/xmlfiles.php
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlfiles.php
@@ -205,6 +205,17 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 			$this->checkFolders($node->folder, $dir);
 		}
 
+		// Check: api files[folder] (filename|file|folder)*
+		if (isset($xml->api->files))
+		{
+			$node = $xml->api->files;
+			$dir = $this->getSourceFolder($node);
+
+			$this->checkFiles($node->filename, $dir);
+			$this->checkFiles($node->file, $dir);
+			$this->checkFolders($node->folder, $dir);
+		}
+
 		// Check file: scriptfile
 		if (isset($xml->scriptfile))
 		{


### PR DESCRIPTION
Joomla!4.0 supports "api" section in component's manifest file (for files in the `/api/components/com_...` directory), and this PR adds support of this section to the XMLFiles checker.