### PR TITLE
Language rule: fix a notice message about incorrect array index

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/language.php
+++ b/administrator/components/com_jedchecker/libraries/rules/language.php
@@ -293,7 +293,7 @@ class JedcheckerRulesLanguage extends JEDcheckerRule
 			// The code below detects incorrect format of numbered placeholders (e.g. "%1s" instead of "%1$s")
 
 			// Count numbered placeholders in the string (e.g. "%1s")
-			$count = preg_match_all('/(?<=^|[^%])%(\d+)\w/', $value, $matches);
+			$count = preg_match_all('/(?<=^|[^%])%(\d+)\w/', $value, $matches, PREG_SET_ORDER);
 
 			if ($count)
 			{


### PR DESCRIPTION
This patch fixes the Language ruleset. Without this patch, issues with placeholders in `*.ini` files were not detected, and a notice message was displayed (if allowed by error_reporting).