### PR TITLE
Fix processing of single-quoted strings and BOM [Language rules]

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/language.php
+++ b/administrator/components/com_jedchecker/libraries/rules/language.php
@@ -199,7 +199,7 @@ class JedcheckerRulesLanguage extends JEDcheckerRule
 			$value = ltrim($value);
 
 			// Parse multiline values
-			while (!preg_match('/^((?>\'(?>[^\'\\\\]+|\\\\.)*\'|"(?>[^"\\\\]+|\\\\.)*"|[^\'";]+)*)(;.*)?$/', $value, $matches))
+			while (!preg_match('/^((?>\'[^\']*\'|"(?>[^"\\\\]+|\\\\.)*"|[^\'";]+)*)(;.*)?$/', $value, $matches))
 			{
 				if ($lineno + 1 >= $nLines)
 				{

--- a/administrator/components/com_jedchecker/libraries/rules/language.php
+++ b/administrator/components/com_jedchecker/libraries/rules/language.php
@@ -113,17 +113,9 @@ class JedcheckerRulesLanguage extends JEDcheckerRule
 			// Check for BOM sequence
 			if ($lineno === 0 && strncmp($line, "\xEF\xBB\xBF", 3) === 0)
 			{
-				// Report as an error if BOM is directly followed by key name (and become a part of the name)
-				if (isset($line[3]) && strpos(";\n\r", $line[3]) === false)
-				{
-					$this->report->addError($file, JText::_('COM_JEDCHECKER_LANG_BOM_FOUND'), $startLineno);
-				}
-				else // Otherwise report a warning
-				{
-					$this->report->addWarning($file, JText::_('COM_JEDCHECKER_LANG_BOM_FOUND'), $startLineno);
-				}
+				$this->report->addWarning($file, JText::_('COM_JEDCHECKER_LANG_BOM_FOUND'), $startLineno);
 
-				// Romeve BOM for further checks
+				// Remove BOM for further checks
 				$line = substr($line, 3);
 			}
 


### PR DESCRIPTION
Thanks to discussion in PR #141, I've learned in details how ini parsing works in PHP. In particular:
1. Single-quoted strings don't support escaping at all.
2. BOM prefix is removed automatically before the parsing (since PHP 5.3). I kept it to be warning-level because it is mentioned on [Language Guidelines for 3rd Party Extensions](https://docs.joomla.org/Language_Guidelines_for_3rd_Party_Extensions), but actually it seems to be not a real issue, and could be mitigated to the notice level.