### PR TITLE
Use placeholders instead of escaped quotes [Language rules]

### DIFF
--- a/administrator/components/com_jedchecker/language/en-GB/en-GB.com_jedchecker.ini
+++ b/administrator/components/com_jedchecker/language/en-GB/en-GB.com_jedchecker.ini
@@ -138,7 +138,7 @@ COM_JEDCHECKER_LANG_TRANSLATION_QUOTES="All translation strings should be enclos
 COM_JEDCHECKER_LANG_TRANSLATION_MISSED_LEFT_QUOTE="You have missed the left quote."
 COM_JEDCHECKER_LANG_TRANSLATION_MISSED_RIGHT_QUOTE="You have missed the right quote"
 COM_JEDCHECKER_LANG_TRANSLATION_EMPTY="Empty translation string"
-COM_JEDCHECKER_LANG_QQDEPRECATED="Usage of \"_QQ_\" is deprecated since Joomla! 3.9. Use escaped double quotes (\\") instead"
+COM_JEDCHECKER_LANG_QQDEPRECATED="Usage of %s is deprecated since Joomla! 3.9. Use escaped double quotes (%s) instead"
 COM_JEDCHECKER_LANG_UNESCAPED_QUOTE="Unescaped double quotation mark found"
 COM_JEDCHECKER_LANG_VARIABLE_REF="A variable reference found in the translation string."
 COM_JEDCHECKER_LANG_INCORRECT_ARGNUM="Probably you use incorrect placeholder format (e.g. '%1s' instead of '%1$s'), see <a href='https://www.php.net/manual/en/function.sprintf.php'>printf's argnum format specification</a> for details"

--- a/administrator/components/com_jedchecker/libraries/rules/language.php
+++ b/administrator/components/com_jedchecker/libraries/rules/language.php
@@ -302,7 +302,7 @@ class JedcheckerRulesLanguage extends JEDcheckerRule
 			// Check for legacy "_QQ_" code (deprecated since Joomla! 3.9 in favour of escaped double quote \"; removed in Joomla! 4)
 			if (strpos($value, '"_QQ_"') !== false)
 			{
-				$this->report->addCompat($file, JText::_('COM_JEDCHECKER_LANG_QQDEPRECATED'), $startLineno, $line);
+				$this->report->addCompat($file, JText::sprintf('COM_JEDCHECKER_LANG_QQDEPRECATED', '<code>"_QQ_"</code>', '<code>\\"</code>'), $startLineno, $line);
 			}
 
 			// Convert "_QQ_" to escaped quotes for further analysis


### PR DESCRIPTION
According to discussed earlier, this is the ultimate fix that even wraps pieces of code into `<code>` tags for better UX