### PR TITLE
Fix DTD-JSON declarations for XMLManifest rule

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_language.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_language.json
@@ -15,7 +15,9 @@
       "files": "!",
       "media": "?",
       "fonts": "?",
+      "install": "?",
       "update": "?",
+      "uninstall": "?",
       "updateservers": "?",
       "dlid": "?"
     },
@@ -33,6 +35,22 @@
       "filename": "*",
       "fonts:file": "*",
       "folder": "*"
+    },
+    "install": {
+      "sql": "*"
+    },
+    "update": {
+      "sql": "*",
+      "schemas": "*"
+    },
+    "uninstall": {
+      "sql": "*"
+    },
+    "sql": {
+      "file": "*"
+    },
+    "schemas": {
+      "schemapath": "*"
     },
     "updateservers": {
       "server": "*"
@@ -55,6 +73,9 @@
     ],
     "fonts": [
       "folder"
+    ],
+    "schemapath": [
+      "type"
     ],
     "server": [
       "name",

--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_language.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_language.json
@@ -74,6 +74,10 @@
     "fonts": [
       "folder"
     ],
+    "file": [
+      "charset",
+      "driver"
+    ],
     "schemapath": [
       "type"
     ],

--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_module.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_module.json
@@ -50,6 +50,9 @@
     "sql": {
       "file": "*"
     },
+    "schemas": {
+      "schemapath": "*"
+    },
     "updateservers": {
       "server": "*"
     },
@@ -97,6 +100,9 @@
     "file": [
       "charset",
       "driver"
+    ],
+    "schemapath": [
+      "type"
     ],
     "server": [
       "name",

--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_module.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_module.json
@@ -21,6 +21,7 @@
       "media": "?",
       "updateservers": "?",
       "dlid": "?",
+      "help": "?",
       "config": "?",
       "namespace": "?"
     },
@@ -142,6 +143,10 @@
     ],
     "field": [
       "*"
+    ],
+    "help": [
+      "key",
+      "url"
     ],
     "dlid": [
       "prefix",

--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_package.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_package.json
@@ -82,6 +82,10 @@
       "client",
       "tag"
     ],
+    "file": [
+      "charset",
+      "driver"
+    ],
     "schemapath": [
       "type"
     ],

--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_package.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_package.json
@@ -13,7 +13,9 @@
       "license": "?",
       "changelogurl": "?",
       "scriptfile": "?",
+      "install": "?",
       "update": "?",
+      "uninstall": "?",
       "files": "?",
       "languages": "?",
       "updateservers": "?",
@@ -30,6 +32,22 @@
     },
     "languages": {
       "language": "*"
+    },
+    "install": {
+      "sql": "*"
+    },
+    "update": {
+      "sql": "*",
+      "schemas": "*"
+    },
+    "uninstall": {
+      "sql": "*"
+    },
+    "sql": {
+      "file": "*"
+    },
+    "schemas": {
+      "schemapath": "*"
     },
     "updateservers": {
       "server": "*"
@@ -63,6 +81,9 @@
     "language": [
       "client",
       "tag"
+    ],
+    "schemapath": [
+      "type"
     ],
     "server": [
       "name",

--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_plugin.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_plugin.json
@@ -50,6 +50,9 @@
     "sql": {
       "file": "*"
     },
+    "schemas": {
+      "schemapath": "*"
+    },
     "updateservers": {
       "server": "*"
     },
@@ -98,6 +101,9 @@
     "file": [
       "charset",
       "driver"
+    ],
+    "schemapath": [
+      "type"
     ],
     "server": [
       "name",

--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_plugin.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_plugin.json
@@ -21,6 +21,7 @@
       "media": "?",
       "updateservers": "?",
       "dlid": "?",
+      "help": "?",
       "config": "?",
       "namespace": "?"
     },
@@ -143,6 +144,10 @@
     ],
     "field": [
       "*"
+    ],
+    "help": [
+      "key",
+      "url"
     ],
     "dlid": [
       "prefix",

--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_template.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_template.json
@@ -13,9 +13,6 @@
       "license": "?",
       "changelogurl": "?",
       "scriptfile": "?",
-      "install": "?",
-      "update": "?",
-      "uninstall": "?",
       "files": "?",
       "images": "?",
       "css": "?",
@@ -51,22 +48,6 @@
       "filename": "*",
       "media:file": "*",
       "folder": "*"
-    },
-    "install": {
-      "sql": "*"
-    },
-    "update": {
-      "sql": "*",
-      "schemas": "*"
-    },
-    "uninstall": {
-      "sql": "*"
-    },
-    "sql": {
-      "file": "*"
-    },
-    "schemas": {
-      "schemapath": "*"
     },
     "updateservers": {
       "server": "*"
@@ -106,9 +87,6 @@
     "file": [
       "charset",
       "driver"
-    ],
-    "schemapath": [
-      "type"
     ],
     "server": [
       "name",

--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_template.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_template.json
@@ -21,6 +21,7 @@
       "positions": "=",
       "updateservers": "?",
       "dlid": "?",
+      "help": "?",
       "config": "?"
     },
     "positions": {
@@ -92,6 +93,10 @@
       "name",
       "priority",
       "type"
+    ],
+    "help": [
+      "key",
+      "url"
     ],
     "dlid": [
       "prefix",


### PR DESCRIPTION
- fixed "unknown `schemapath` child" issue (in modules/plugins)
- added support of `install`/`uninstall` nodes in packages/languages
- removed support of `install`/`uninstall` nodes in templates (because of `TemplateAdapter` class overrides `parseQueries` method)
- added support of `help` node in module/plugin/template
