### PR TITLE
Support all archive extensions that Joomla is able to unpack

### DIFF
--- a/administrator/components/com_jedchecker/controllers/uploads.php
+++ b/administrator/components/com_jedchecker/controllers/uploads.php
@@ -192,11 +192,9 @@ class JedcheckerControllerUploads extends JControllerLegacy
 		{
 			if ($file->isFile())
 			{
-				$extension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
-
-				if ($extension === 'zip')
+				if (preg_match('/\.(?:zip|tar|tgz|tbz2|tar\.(?:gz|gzip|bz2|bzip2))$/', $file->getFilename(), $matches))
 				{
-					$unzip  = $file->getPath() . '/' . $file->getBasename('.' . $extension);
+					$unzip  = $file->getPath() . '/' . $file->getBasename($matches[0]);
 
 					try
 					{

--- a/administrator/components/com_jedchecker/controllers/uploads.php
+++ b/administrator/components/com_jedchecker/controllers/uploads.php
@@ -85,11 +85,7 @@ class JedcheckerControllerUploads extends JControllerLegacy
 				}
 			}
 
-			$filepath = $path . '/' . strtolower($file['name']);
-
-			$object_file           = new JObject($file);
-			$object_file->filepath = $filepath;
-			$file                  = (array) $object_file;
+			$file['filepath'] = $path . '/' . strtolower($file['name']);
 
 			// Let us try to upload
 			if (!JFile::upload($file['tmp_name'], $file['filepath'], false, true))

--- a/administrator/components/com_jedchecker/libraries/rules/xmlfiles.php
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlfiles.php
@@ -367,7 +367,7 @@ class JedcheckerRulesXMLFiles extends JEDcheckerRule
 			}
 
 			// Extra check for unzipped files
-			if (preg_match('/^(.*)\.(zip|tgz|tar\.gz)$/', $filename, $matches) && is_dir($matches[1]))
+			if (preg_match('/^(.*)\.(?:zip|tar|tgz|tbz2|tar\.(?:gz|gzip|bz2|bzip2))$/', $filename, $matches) && is_dir($matches[1]))
 			{
 				continue;
 			}


### PR DESCRIPTION
The following file extensions are supported by Joomla! installer: zip, tar, tgz, tbz2, tar.gz, tar.gzip, tar.bz2, tar.bzip2.