### PR TITLE
Fix Encoding ruleset

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/encoding.ini
+++ b/administrator/components/com_jedchecker/libraries/rules/encoding.ini
@@ -7,4 +7,4 @@
 ; @license    GNU General Public License version 2 or later; see LICENSE.txt
 
 ; The valid constants to search for
-encodings ="base64,base64_decode,base64_encode,zlib_decode,zlib_encode"
+encodings ="base64_decode,base64_encode,zlib_decode,zlib_encode"

--- a/administrator/components/com_jedchecker/libraries/rules/encoding.php
+++ b/administrator/components/com_jedchecker/libraries/rules/encoding.php
@@ -120,7 +120,7 @@ class JedcheckerRulesEncoding extends JEDcheckerRule
 			if (preg_match($this->encodingsRegex, $line))
 			{
 				$found = true;
-				$this->report->addError($file, JText::_('COM_JEDCHECKER_ERROR_ENCODING'), $i + 1, $line);
+				$this->report->addWarning($file, JText::_('COM_JEDCHECKER_ERROR_ENCODING'), $i + 1, $line);
 			}
 		}
 


### PR DESCRIPTION
1) Don't warn on base64-encoded data-uri (full PHP function names `base64_encode` and `base64_decode` are checked only),
2) Mitigate Encoding ruleset to the warning level as it's widely used to encode/decode a "return" page, to generate data-uri, to serialize binary signatures or tokens (e.g. sha-256 hash), etc.