### PR TITLE
php 8.1 deprecation

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/gpl.php
+++ b/administrator/components/com_jedchecker/libraries/rules/gpl.php
@@ -106,7 +106,7 @@ class JedcheckerRulesGpl extends JEDcheckerRule
 
 		$compatLicenses = (array) file(__DIR__ . '/gpl/compat.txt');
 
-		$extraLicenses = $this->params->get('constants');
+		$extraLicenses = $this->params->get('constants', '');
 		$extraLicenses = explode(',', $extraLicenses);
 
 		$compatLicenses = array_merge($compatLicenses, $extraLicenses);


### PR DESCRIPTION
as the title say

i've got  `PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in /shared/httpd/joomla-cms/joomla/administrator/components/com_jedchecker/libraries/rules/gpl.php on line 110`