### PR TITLE
Fix processing of strings in `JEDCheckerHelper::cleanPhpCode` method

### DIFF
--- a/administrator/components/com_jedchecker/libraries/helper.php
+++ b/administrator/components/com_jedchecker/libraries/helper.php
@@ -192,7 +192,7 @@ abstract class JEDCheckerHelper
 					break;
 
 				case '`':
-					if (!preg_match("/`.*?`/As", $content, $match, 0, $pos))
+					if (!preg_match("/`(?>[^`\\\\]+|\\\\.)*`/As", $content, $match, 0, $pos))
 					{
 						return $cleanContent . substr($content, $pos);
 					}

--- a/administrator/components/com_jedchecker/libraries/helper.php
+++ b/administrator/components/com_jedchecker/libraries/helper.php
@@ -309,7 +309,7 @@ abstract class JEDCheckerHelper
 		$pos = 0;
 		$cleanContent = '';
 
-		while (preg_match('/\n|\\|\{\$|\$\{/', $content, $match, PREG_OFFSET_CAPTURE, $pos))
+		while (preg_match('/\n|\\\\|\{\$|\$\{/', $content, $match, PREG_OFFSET_CAPTURE, $pos))
 		{
 			$foundPos = $match[0][1];
 			$cleanContent .= substr($content, $pos, $foundPos - $pos);

--- a/administrator/components/com_jedchecker/libraries/helper.php
+++ b/administrator/components/com_jedchecker/libraries/helper.php
@@ -2,7 +2,7 @@
 /**
  * @package    Joomla.JEDChecker
  *
- * @copyright  Copyright (C) 2021 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2021-2022 Open Source Matters, Inc. All rights reserved.
  *
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */

--- a/administrator/components/com_jedchecker/libraries/helper.php
+++ b/administrator/components/com_jedchecker/libraries/helper.php
@@ -303,7 +303,7 @@ abstract class JEDCheckerHelper
 	{
 		if (!$parse)
 		{
-			return str_repeat("\n", substr_count($content, "\n"));
+			return self::cleanLines($content);
 		}
 
 		$pos = 0;
@@ -312,7 +312,7 @@ abstract class JEDCheckerHelper
 		while (preg_match('/\n|\\\\|\{\$|\$\{/', $content, $match, PREG_OFFSET_CAPTURE, $pos))
 		{
 			$foundPos = $match[0][1];
-			$cleanContent .= substr($content, $pos, $foundPos - $pos);
+			$cleanContent .= self::cleanLines(substr($content, $pos, $foundPos - $pos));
 			$pos = $foundPos;
 
 			switch ($match[0][0])
@@ -383,5 +383,18 @@ abstract class JEDCheckerHelper
 		}
 
 		return $cleanContent;
+	}
+
+	/**
+	 * Remove all content except of EOLs to preserve line numbers
+	 *
+	 * @param string $content
+	 *
+	 * @return string
+	 * @since 2.4.2
+	 */
+	protected static function cleanLines($content)
+	{
+		return str_repeat("\n", substr_count($content, "\n"));
 	}
 }


### PR DESCRIPTION
1. Fix processing of escaped characters in the backtick operator (e.g. `` `...\`...` ``) and quoted strings.
2. Fix cleaning of text content in double-quoted strings (but keeping variable/code injections).