### PR TITLE
Fix displaying unmodified file content in error message(s)

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/encoding.php
+++ b/administrator/components/com_jedchecker/libraries/rules/encoding.php
@@ -2,7 +2,7 @@
 /**
  * @package    Joomla.JEDChecker
  *
- * @copyright  Copyright (C) 2017 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2017 - 2022 Open Source Matters, Inc. All rights reserved.
  * 			   Copyright (C) 2008 - 2016 compojoom.com . All rights reserved.
  * @author     Daniel Dimitrov <daniel@compojoom.com>
  * 			   02.06.12

--- a/administrator/components/com_jedchecker/libraries/rules/encoding.php
+++ b/administrator/components/com_jedchecker/libraries/rules/encoding.php
@@ -105,6 +105,7 @@ class JedcheckerRulesEncoding extends JEDcheckerRule
 	protected function find($file)
 	{
 		$content = file_get_contents($file);
+		$origContent = JEDCheckerHelper::splitLines($content);
 
 		// Exclude comments
 		$content = JEDCheckerHelper::cleanPhpCode(
@@ -120,7 +121,7 @@ class JedcheckerRulesEncoding extends JEDcheckerRule
 			if (preg_match($this->encodingsRegex, $line))
 			{
 				$found = true;
-				$this->report->addWarning($file, JText::_('COM_JEDCHECKER_ERROR_ENCODING'), $i + 1, $line);
+				$this->report->addWarning($file, JText::_('COM_JEDCHECKER_ERROR_ENCODING'), $i + 1, $origContent[$i]);
 			}
 		}
 

--- a/administrator/components/com_jedchecker/libraries/rules/errorreporting.php
+++ b/administrator/components/com_jedchecker/libraries/rules/errorreporting.php
@@ -2,7 +2,7 @@
 /**
  * @package    Joomla.JEDChecker
  *
- * @copyright  Copyright (C) 2017 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2017 - 2022 Open Source Matters, Inc. All rights reserved.
  * 			   Copyright (C) 2008 - 2016 mijosoft.com . All rights reserved.
  * @author     Denis Dulici <denis@mijosoft.com>
  *

--- a/administrator/components/com_jedchecker/libraries/rules/errorreporting.php
+++ b/administrator/components/com_jedchecker/libraries/rules/errorreporting.php
@@ -106,6 +106,7 @@ class JedcheckerRulesErrorreporting extends JEDcheckerRule
 	protected function find($file)
 	{
 		$content = file_get_contents($file);
+		$origContent = JEDCheckerHelper::splitLines($content);
 
 		// Exclude non-code content
 		$content = JEDCheckerHelper::cleanPhpCode(
@@ -121,7 +122,7 @@ class JedcheckerRulesErrorreporting extends JEDcheckerRule
 			if (preg_match($this->errorreportingRegex, $line))
 			{
 				$found = true;
-				$this->report->addWarning($file, JText::_('COM_JEDCHECKER_ERROR_ERRORREPORTING'), $i + 1, $line);
+				$this->report->addWarning($file, JText::_('COM_JEDCHECKER_ERROR_ERRORREPORTING'), $i + 1, $origContent[$i]);
 			}
 		}
 

--- a/administrator/components/com_jedchecker/libraries/rules/jamss.php
+++ b/administrator/components/com_jedchecker/libraries/rules/jamss.php
@@ -340,6 +340,7 @@ class JedcheckerRulesJamss extends JEDcheckerRule
 			}
 			else
 			{
+				$origContent = JEDCheckerHelper::splitLines($content);
 				$scopes = array(
 					'full' => $content,
 					'clean' => JEDCheckerHelper::cleanPhpCode($content, JEDCheckerHelper::CLEAN_COMMENTS),
@@ -403,8 +404,8 @@ class JedcheckerRulesJamss extends JEDcheckerRule
 								$end = strlen($scoped_content);
 							}
 
-							$first_code = substr($scoped_content, $start, min($end - $start, 200));
 							$first_line = $this->calculate_line_number($offset, $scoped_content);
+							$first_code = $origContent[$first_line - 1];
 							break;
 						}
 

--- a/administrator/components/com_jedchecker/libraries/rules/jamss.php
+++ b/administrator/components/com_jedchecker/libraries/rules/jamss.php
@@ -2,7 +2,7 @@
 /**
  * @package    Joomla.JEDChecker
  *
- * @copyright  Copyright (C) 2017 - 2021 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2017 - 2022 Open Source Matters, Inc. All rights reserved.
  * 			   Copyright (C) 2008 - 2016 fasterjoomla.com. All rights reserved.
  * @author     Riccardo Zorn <support@fasterjoomla.com>
  * 			   Bernard Toplak <bernard@orion-web.hr>


### PR DESCRIPTION
Keep full original content (i.e. comments, strings, and other "cleaned" content) in error messages in Encoding, ErrorReporting, and JAMSS rules