### PR TITLE
Fix skipping `*jamss.php` files/directories in the JAMSS rule

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/jamss.php
+++ b/administrator/components/com_jedchecker/libraries/rules/jamss.php
@@ -324,8 +324,7 @@ class JedcheckerRulesJamss extends JEDcheckerRule
 		 */
 
 		if (in_array(pathinfo($path, PATHINFO_EXTENSION), $ext)
-			&& filesize($path)/* skip empty ones */
-			&& !stripos($path, 'jamss.php')/* skip this file */)
+			&& filesize($path)/* skip empty ones */)
 			{
 			if ($malic_file_descr = array_search(pathinfo($path, PATHINFO_BASENAME), $jamssFileNames))
 			{


### PR DESCRIPTION
Currently it's possible to bypass JAMSS check by naming the PHP file as "jamss.php", or by creating same-name directory and put files there. This patch fixes this "back door".