### PR TITLE
Fix visibility of accordion collapse button with Bootstrap 5.2

### DIFF
--- a/media/com_jedchecker/js/script.js
+++ b/media/com_jedchecker/js/script.js
@@ -78,6 +78,7 @@
 
       if (!jed_collapse_init) {
         [...document.querySelectorAll('.card-header[data-bs-toggle]')].forEach(el => {
+          el.classList.add('accordion');
           el.classList.add('accordion-button');
           el.classList.add('collapsed');
           el.setAttribute('href', el.dataset.href);


### PR DESCRIPTION
Accordion button to collapse/open cards is not displayed in Joomla 4.3 with Bootstrap 5.2. This patch fixes the issue.