### PR TITLE
Fixed conflict of Bootstrap with jQuery scrollspy

### DIFF
--- a/media/com_jedchecker/js/script.js
+++ b/media/com_jedchecker/js/script.js
@@ -103,4 +103,8 @@
   });
 
   new bootstrap.Tooltip(document.getElementById('jedchecker'), {container: 'body', selector: '[data-bs-toggle=tooltip]'});
+
+  document.addEventListener('DOMContentLoaded', () => {
+    jQuery.fn.scrollspy.noConflict();
+  }, true);
 })();


### PR DESCRIPTION
In Joomla 3.x there was a conflict of Bootstrap and jQuery scrollspy plugin (see issue #206). This patch fixes it by calling `noConflict()` method on Bootstrap's implementation.