### PR TITLE
Display a notice if en-GB sys.ini file is missed

### DIFF
--- a/administrator/components/com_jedchecker/language/en-GB/en-GB.com_jedchecker.ini
+++ b/administrator/components/com_jedchecker/language/en-GB/en-GB.com_jedchecker.ini
@@ -56,6 +56,7 @@ COM_JEDCHECKER_INFO_XML_URL_JOOMLA_DERIVATIVE="Domain names that use 'Joomla' or
 COM_JEDCHECKER_INFO_XML_NAME_TOO_LONG="Listing name ('%s') is too long, consider to shorten it"
 COM_JEDCHECKER_INFO_XML_NAME_ADMIN_MENU="The admin menu name '%1$s' isn't the same as the extension name '%2$s'"
 COM_JEDCHECKER_INFO_XML_NAME_PLUGIN_FORMAT="The name of the plugin ('%s') must comply with the JED naming conventions in the form '{Type} - {Extension Name}'"
+COM_JEDCHECKER_INFO_XML_NO_LANGUAGE_FILE_FOUND="No '%1$s' language file was found for the '%2$s' language tag."
 COM_JEDCHECKER_RULE_PH1="PHP Headers missing GPL License Notice"
 COM_JEDCHECKER_RULE_PH1_DESC="A notice is required on each PHP file stating that the file is licensed GPL (or other compatible accepted license). For more information, please <a href='https://extensions.joomla.org/support/knowledgebase/submission-requirements/jed-entries-checklists/#licensechecklist' target='_blank'>click here</a>."
 COM_JEDCHECKER_ERROR_GPL_NOT_FOUND="GPL or compatible license was not found"


### PR DESCRIPTION
This pull request is a result of our discussions regarding error messages generated by JEDChecker for a plugin that includes a Russian translation but lacks an English translation. After merging this pull request, the "Information about extension XML files" menu will display the message

`No '....sys.ini' language file was found for the 'en-GB' language tag.`

if such a file is missing.

This message is currently displayed when such a file is missing, but it's important to note that extensions are not required to include this file. In certain scenarios, displaying this message may confuse users, especially since it's displayed on the main results page.

In addition, I have long-term plans (albeit in the distant future) to implement a check to ensure that the contents of language files are consistent with the en-GB language. When that check is implemented, the need for this specific check will become redundant, as it will be completely covered by the new check.

Therefore, I am inclined to recommend against merging this pull request at this time. However, I am open to discussion and welcome differing opinions from the team. Please feel free to share your thoughts on this matter.