### PR TITLE
Add support of config section in template manifest

### DIFF
--- a/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_template.json
+++ b/administrator/components/com_jedchecker/libraries/rules/xmlmanifest/dtd_template.json
@@ -52,6 +52,18 @@
     },
     "updateservers": {
       "server": "*"
+    },
+    "config": {
+      "fields": "!"
+    },
+    "fields": {
+      "fieldset": "+"
+    },
+    "fieldset": {
+      "field": "+"
+    },
+    "field": {
+      "*": "*"
     }
   },
   "attributes": {
@@ -93,6 +105,37 @@
       "name",
       "priority",
       "type"
+    ],
+    "config": [
+      "addfieldpath",
+      "addfieldprefix",
+      "addformpath",
+      "addformprefix",
+      "addrulepath",
+      "addruleprefix"
+    ],
+    "fields": [
+      "addfieldpath",
+      "addfieldprefix",
+      "addformpath",
+      "addformprefix",
+      "addrulepath",
+      "addruleprefix",
+      "name"
+    ],
+    "fieldset": [
+      "addfieldpath",
+      "addfieldprefix",
+      "addformpath",
+      "addformprefix",
+      "addrulepath",
+      "addruleprefix",
+      "description",
+      "label",
+      "name"
+    ],
+    "field": [
+      "*"
     ],
     "help": [
       "key",


### PR DESCRIPTION
Templates are not supported by JED, but they may be a part of a package (e.g. for AMP version of website), that's why it's good to correctly check template's manifest structure.