### PR TITLE
Resolve aliases before checking framework rules

### DIFF
--- a/administrator/components/com_jedchecker/libraries/helper.php
+++ b/administrator/components/com_jedchecker/libraries/helper.php
@@ -399,4 +399,25 @@ abstract class JEDCheckerHelper
 	{
 		return str_repeat("\n", substr_count($content, "\n"));
 	}
+
+	public static function resolveAliases($content)
+	{
+		if (preg_match_all('/\buse\s+([\\\\\w]+)(?:\s+as\s+(\w+))?\s*;/i', $content, $matches, PREG_SET_ORDER)) {
+			foreach ($matches as $match) {
+				$fqn = $match[1];
+
+				if (isset($match[2])) {
+					$alias = $match[2];
+				} else {
+					$path = explode('\\', $fqn);
+					$alias = $path[count($path) - 1];
+				}
+
+				$content = str_replace($match[0], self::cleanLines($match[0]), $content);
+				$content = preg_replace('/\b' . $alias . '\b/', $fqn, $content);
+			}
+		}
+
+		return $content;
+	}
 }

--- a/administrator/components/com_jedchecker/libraries/rules/framework.php
+++ b/administrator/components/com_jedchecker/libraries/rules/framework.php
@@ -173,6 +173,7 @@ class JedcheckerRulesFramework extends JEDcheckerRule
 			$content,
 			JEDCheckerHelper::CLEAN_HTML | JEDCheckerHelper::CLEAN_COMMENTS | JEDCheckerHelper::CLEAN_STRINGS
 		);
+		$cleanContent = JEDCheckerHelper::resolveAliases($cleanContent);
 
 		// Check short PHP tag
 		if (preg_match('/<\?\s/', $cleanContent, $match, PREG_OFFSET_CAPTURE))


### PR DESCRIPTION
It seems to me that many will adapt extensions for Joomla 5 using aliases, for example:
```php
use Joomla\CMS\Factory as JFactory;
```

To prevent JEDChecker from complaining about using the `JFactory` class in such cases, I added a detection and substitution of all aliases in the source code before checking.