### PR TITLE
Fix extension package upload on Joomla 6.1.2+

### DIFF
--- a/src/administrator/components/com_jedchecker/src/Controller/UploadsController.php
+++ b/src/administrator/components/com_jedchecker/src/Controller/UploadsController.php
@@ -134,7 +134,7 @@ class UploadsController extends BaseController
 
         $file['filepath'] = $archivePath . '/' . strtolower($filename);
 
-        if (! File::upload($file['tmp_name'], $file['filepath'], false)) {
+        if (! File::upload($file['tmp_name'], $file['filepath'], false, true)) {
             $app->enqueueMessage(Text::_('COM_JEDCHECKER_ERROR_UNABLE_TO_UPLOAD_FILE'), 'error');
             $app->redirect('index.php?option=com_jedchecker&view=uploads');
 


### PR DESCRIPTION
This PR fixes extension package upload failures observed on Joomla 6.1.2+.

Error observed during upload:
Joomla\\Filesystem\\File::upload: File not uploaded for security reasons!

Current call in JED Checker:
File::upload($file['tmp_name'], $file['filepath'], false)

Changed call:
File::upload($file['tmp_name'], $file['filepath'], false, true)

Result:
- Upload fails with the current call on Joomla 6.1.2 and 6.1.3.
- Upload succeeds with the changed call (verified on Joomla 6.1.3).

Based on maintainer discussion, File::upload hardening was reintroduced by default in Joomla 6.1.2, and this upload path appears to require the filter override for extension packages that may contain PHP files.

References #276

## Testing
- Reproduced on Joomla 6.1.3 with the current call: upload fails with "File not uploaded for security reasons!".
- Verified on Joomla 6.1.3 with the changed call: upload succeeds.
- Joomla 6.1.2 re-test was not executed in this environment.